### PR TITLE
Adding logging to error controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,21 @@ will run accordingly.
 
 Throwing an uncaught exception from a controller will cause a response with the exception details encoded in JSON.  The
 status code will usually be 500.  If the exception implements
-```Sainsburys\HttpService\Components\ErrorHandling\Exceptions\ExceptionWithHttpStatus```, the status code on the exception will be used.
+```Sainsburys\HttpService\Components\ErrorHandling\Exceptions\ExceptionWithHttpStatus```, the status code on the
+exception will be used.
 
 If you wish to implement your own error handler, for example if you don't want stack traces being visible in the
 response in production, call ```Sainsburys\HttpService\Application::useThisErrorController()'``` in your
 ```index.php``` file, and give it a different error controller it can use.
+
+**Error Logging**
+
+Your error controller will be passed a ```Psr\Log\LoggerInterface```, which by default will be a
+```Psr\Log\NullLogger```.  This does nothing.  To do error logging, call ```Application::useThisLogger()```.  You will
+need a PSR-3 compliant logger for this.  We suggest that you pass your choice of logging object into your other
+controllers or other classes as well, where logging is required.  You can do this when you configure the dependencies of
+your controller in your DI container.  The [Monolog logging tool](https://github.com/Seldaek/monolog) may be a good
+choice of logging library in PHP if you are looking for ideas.
 
 Installation
 ------------

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 
         "samburns/pimple3-containerinterop":   "^1.0",
         "psr/http-message":                    "1.0.0",
+        "psr/log":                             "1.0.0",
         "slim/slim":                           "^3.0.0-RC3",
         "zendframework/zend-diactoros":        "^1.0",
         "shrikeh/teapot":                      "^1.0",

--- a/src/Sainsburys/HttpService/Application.php
+++ b/src/Sainsburys/HttpService/Application.php
@@ -1,6 +1,8 @@
 <?php
 namespace Sainsburys\HttpService;
 
+use Psr\Log\LoggerInterface;
+use Sainsburys\HttpService\Components\Logging\LoggingManager;
 use Sainsburys\HttpService\Components\ErrorHandling\ErrorController\ErrorControllerManager;
 use SamBurns\Pimple3ContainerInterop\ServiceContainer;
 use Sainsburys\HttpService\Components\ErrorHandling\ErrorController\ErrorController;
@@ -28,6 +30,9 @@ class Application
     /** @var MiddlewareManager */
     private $middlewareManager;
 
+    /** @var LoggingManager */
+    private $loggingManager;
+
     /** @var ContainerInterface */
     private $container;
 
@@ -40,19 +45,22 @@ class Application
      * @param RoutingConfigApplier   $routingConfigApplier
      * @param ErrorControllerManager $errorControllerManager
      * @param MiddlewareManager      $middlewareManager
+     * @param LoggingManager         $loggingManager
      */
     public function __construct(
         SlimApplication        $slimApplication,
         RoutingConfigReader    $routingConfigReader,
         RoutingConfigApplier   $routingConfigApplier,
         ErrorControllerManager $errorControllerManager,
-        MiddlewareManager      $middlewareManager
+        MiddlewareManager      $middlewareManager,
+        LoggingManager         $loggingManager
     ) {
         $this->slimApplication        = $slimApplication;
         $this->routingConfigReader    = $routingConfigReader;
         $this->routingConfigApplier   = $routingConfigApplier;
         $this->errorControllerManager = $errorControllerManager;
         $this->middlewareManager      = $middlewareManager;
+        $this->loggingManager         = $loggingManager;
     }
 
     /**
@@ -109,6 +117,14 @@ class Application
     public function useThisErrorController(ErrorController $errorController)
     {
         $this->errorControllerManager->useThisErrorController($errorController);
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function useThisLogger(LoggerInterface $logger)
+    {
+        $this->loggingManager->useThisLogger($logger);
     }
 
     /**

--- a/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/DefaultErrorController.php
+++ b/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/DefaultErrorController.php
@@ -15,13 +15,35 @@ class DefaultErrorController implements ErrorController
      */
     public function handleError(\Exception $exception, LoggerInterface $logger)
     {
+        $this->logError($exception, $logger);
+        $response = $this->prepareHttpResponse($exception);
+
+        return $response;
+    }
+
+    /**
+     * @param \Exception      $exception
+     * @param LoggerInterface $logger
+     */
+    private function logError(\Exception $exception, LoggerInterface $logger)
+    {
+        $logger->critical(
+            get_class($exception) . ': ' . $exception->getMessage(),
+            $exception->getTrace()
+        );
+    }
+
+    /**
+     * @param \Exception $exception
+     * @return JsonResponse
+     */
+    private function prepareHttpResponse(\Exception $exception)
+    {
         $responseBodyArray = [
             'exception-class' => get_class($exception),
             'message'         => $exception->getMessage(),
-            'stack-trace'     => $exception->getTraceAsString()
+            'stack-trace'     => $exception->getTrace()
         ];
-
-        $logger->critical($exception->getMessage(), $responseBodyArray);
 
         $statusCode = $exception instanceof ExceptionWithHttpStatus ? $exception->getHttpStatusCode() : 500;
 

--- a/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/DefaultErrorController.php
+++ b/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/DefaultErrorController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Sainsburys\HttpService\Components\ErrorHandling\ErrorController;
 
+use Psr\Log\LoggerInterface;
 use Sainsburys\HttpService\Components\ErrorHandling\Exceptions\ExceptionWithHttpStatus;
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response\JsonResponse;
@@ -8,16 +9,19 @@ use Zend\Diactoros\Response\JsonResponse;
 class DefaultErrorController implements ErrorController
 {
     /**
-     * @param \Exception $exception
+     * @param \Exception      $exception
+     * @param LoggerInterface $logger
      * @return ResponseInterface
      */
-    public function handleError(\Exception $exception)
+    public function handleError(\Exception $exception, LoggerInterface $logger)
     {
         $responseBodyArray = [
             'exception-class' => get_class($exception),
             'message'         => $exception->getMessage(),
             'stack-trace'     => $exception->getTraceAsString()
         ];
+
+        $logger->critical($exception->getMessage(), $responseBodyArray);
 
         $statusCode = $exception instanceof ExceptionWithHttpStatus ? $exception->getHttpStatusCode() : 500;
 

--- a/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/ErrorController.php
+++ b/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/ErrorController.php
@@ -2,12 +2,14 @@
 namespace Sainsburys\HttpService\Components\ErrorHandling\ErrorController;
 
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
 
 interface ErrorController
 {
     /**
-     * @param \Exception $exception
+     * @param \Exception      $exception
+     * @param LoggerInterface $logger
      * @return ResponseInterface
      */
-    public function handleError(\Exception $exception);
+    public function handleError(\Exception $exception, LoggerInterface $logger);
 }

--- a/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/ProductionExternalisedErrorController.php
+++ b/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/ProductionExternalisedErrorController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Sainsburys\HttpService\Components\ErrorHandling\ErrorController;
 
+use Psr\Log\LoggerInterface;
 use Sainsburys\HttpService\Components\ErrorHandling\Exceptions\ExceptionWithHttpStatus;
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response\JsonResponse;
@@ -8,14 +9,17 @@ use Zend\Diactoros\Response\JsonResponse;
 class ProductionExternalisedErrorController implements ErrorController
 {
     /**
-     * @param \Exception $exception
+     * @param \Exception      $exception
+     * @param LoggerInterface $logger
      * @return ResponseInterface
      */
-    public function handleError(\Exception $exception)
+    public function handleError(\Exception $exception, LoggerInterface $logger)
     {
         $responseBodyArray = [
             'exception-class' => get_class($exception)
         ];
+
+        $logger->critical($exception->getMessage(), $responseBodyArray);
 
         $statusCode = $exception instanceof ExceptionWithHttpStatus ? $exception->getHttpStatusCode() : 500;
 

--- a/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/ProductionExternalisedErrorController.php
+++ b/src/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/ProductionExternalisedErrorController.php
@@ -15,11 +15,33 @@ class ProductionExternalisedErrorController implements ErrorController
      */
     public function handleError(\Exception $exception, LoggerInterface $logger)
     {
-        $responseBodyArray = [
-            'exception-class' => get_class($exception)
-        ];
+        $this->logError($exception, $logger);
+        $response = $this->prepareHttpResponse($exception);
 
-        $logger->critical($exception->getMessage(), $responseBodyArray);
+        return $response;
+    }
+
+    /**
+     * @param \Exception      $exception
+     * @param LoggerInterface $logger
+     */
+    private function logError(\Exception $exception, LoggerInterface $logger)
+    {
+        $logger->critical(
+            get_class($exception) . ': ' . $exception->getMessage(),
+            $exception->getTrace()
+        );
+    }
+
+    /**
+     * @param \Exception $exception
+     * @return JsonResponse
+     */
+    private function prepareHttpResponse(\Exception $exception)
+    {
+        $responseBodyArray = [
+            'error-message' => 'We\'re sorry, an internal server error occurred.'
+        ];
 
         $statusCode = $exception instanceof ExceptionWithHttpStatus ? $exception->getHttpStatusCode() : 500;
 

--- a/src/Sainsburys/HttpService/Components/Logging/LoggingManager.php
+++ b/src/Sainsburys/HttpService/Components/Logging/LoggingManager.php
@@ -1,0 +1,34 @@
+<?php
+namespace Sainsburys\HttpService\Components\Logging;
+
+use Psr\Log\LoggerInterface;
+
+class LoggingManager
+{
+    /** @var LoggerInterface */
+    private $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function useThisLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    public function logger()
+    {
+        return $this->logger;
+    }
+}

--- a/src/Sainsburys/HttpService/Misc/DiConfig.php
+++ b/src/Sainsburys/HttpService/Misc/DiConfig.php
@@ -8,6 +8,7 @@ use Sainsburys\HttpService\Components\ControllerClosures\ControllerClosureBuilde
 use Sainsburys\HttpService\Components\ControllerClosures\ControllerClosureBuilder\SimpleControllerClosureBuilder;
 use Sainsburys\HttpService\Application;
 use Sainsburys\HttpService\Components\ErrorHandling\ErrorController\DefaultErrorController;
+use Sainsburys\HttpService\Components\Logging\LoggingManager;
 use Sainsburys\HttpService\Components\Routing\FileWork\PhpArrayConfigFileReader;
 use Sainsburys\HttpService\Components\Middlewares\MiddlewareLibrary\BeforeMiddleware\CleanRequestAttributes;
 use Sainsburys\HttpService\Components\Middlewares\MiddlewareLibrary\BeforeMiddleware\ConvertToJsonResponseObject;
@@ -16,6 +17,7 @@ use Sainsburys\HttpService\Components\Routing\RoutingConfigApplier;
 use Sainsburys\HttpService\Components\Routing\RoutingConfigReader;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use Psr\Log\NullLogger;
 use Slim\App as SlimApplication;
 
 class DiConfig implements ServiceProviderInterface
@@ -33,13 +35,15 @@ class DiConfig implements ServiceProviderInterface
                 $routingConfigApplier   = new RoutingConfigApplier($container['ents.http-mvc-service.controller-closure-builder']);
                 $errorControllerManager = $container['ents.http-mvc-service.error-controller-manager'];
                 $middlewareManager      = $container['ents.http-mvc-service.middleware-manager'];
+                $loggingManager         = $container['ents.http-mvc-service.logging-manager'];
 
                 return new Application(
                     $slimApplication,
                     $routingConfigReader,
                     $routingConfigApplier,
                     $errorControllerManager,
-                    $middlewareManager
+                    $middlewareManager,
+                    $loggingManager
                 );
             };
 
@@ -53,7 +57,8 @@ class DiConfig implements ServiceProviderInterface
                             ),
                             $container['ents.http-mvc-service.middleware-manager']
                         ),
-                        $container['ents.http-mvc-service.error-controller-manager']
+                        $container['ents.http-mvc-service.error-controller-manager'],
+                        $container['ents.http-mvc-service.logging-manager']
                     );
             };
 
@@ -68,6 +73,11 @@ class DiConfig implements ServiceProviderInterface
         $container['ents.http-mvc-service.error-controller-manager'] =
             function (Container $container) {
                 return new ErrorControllerManager(new DefaultErrorController());
+            };
+
+        $container['ents.http-mvc-service.logging-manager'] =
+            function (Container $container) {
+                return new LoggingManager(new NullLogger());
             };
     }
 }

--- a/tests/phpspec/SainsburysSpec/Sainsburys/HttpService/ApplicationSpec.php
+++ b/tests/phpspec/SainsburysSpec/Sainsburys/HttpService/ApplicationSpec.php
@@ -1,8 +1,10 @@
 <?php
 namespace SainsburysSpec\Sainsburys\HttpService;
 
+use Psr\Log\LoggerInterface;
 use Sainsburys\HttpService\Application;
 use Sainsburys\HttpService\Components\ErrorHandling\ErrorController\ErrorControllerManager;
+use Sainsburys\HttpService\Components\Logging\LoggingManager;
 use Sainsburys\HttpService\Components\Middlewares\MiddlewareManager;
 use Sainsburys\HttpService\Components\Routing\Route;
 use Interop\Container\ContainerInterface;
@@ -23,10 +25,16 @@ class ApplicationSpec extends ObjectBehavior
         RoutingConfigReader    $routingConfigReader,
         RoutingConfigApplier   $routingConfigApplier,
         ErrorControllerManager $errorControllerManager,
-        MiddlewareManager      $middlewareManager
+        MiddlewareManager      $middlewareManager,
+        LoggingManager         $loggingManager
     ) {
         $this->beConstructedWith(
-            $slimApplication, $routingConfigReader, $routingConfigApplier, $errorControllerManager, $middlewareManager
+            $slimApplication,
+            $routingConfigReader,
+            $routingConfigApplier,
+            $errorControllerManager,
+            $middlewareManager,
+            $loggingManager
         );
     }
 
@@ -83,6 +91,17 @@ class ApplicationSpec extends ObjectBehavior
 
         // ASSERT
         $errorControllerManager->useThisErrorController($newErrorController)->shouldHaveBeenCalled();
+    }
+
+    function it_lets_you_put_another_logger(
+        LoggerInterface $logger,
+        LoggingManager  $loggingManager
+    ) {
+        // ACT
+        $this->useThisLogger($logger);
+
+        // ASSERT
+        $loggingManager->useThisLogger($logger)->shouldHaveBeenCalled();
     }
 
     function it_can_return_the_middleware_manager(MiddlewareManager $middlewareManager)

--- a/tests/phpspec/SainsburysSpec/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/DefaultErrorControllerSpec.php
+++ b/tests/phpspec/SainsburysSpec/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/DefaultErrorControllerSpec.php
@@ -38,6 +38,6 @@ class DefaultErrorControllerSpec extends ObjectBehavior
         $result = $this->handleError($exception, $logger);
 
         // ASSERT
-        $logger->critical(Argument::any(), Argument::any())->shouldHaveBeenCalled();
+        $logger->critical('Exception: message', $exception->getTrace())->shouldHaveBeenCalled();
     }
 }

--- a/tests/phpspec/SainsburysSpec/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/DefaultErrorControllerSpec.php
+++ b/tests/phpspec/SainsburysSpec/Sainsburys/HttpService/Components/ErrorHandling/ErrorController/DefaultErrorControllerSpec.php
@@ -1,6 +1,7 @@
 <?php
 namespace SainsburysSpec\Sainsburys\HttpService\Components\ErrorHandling\ErrorController;
 
+use Psr\Log\LoggerInterface;
 use Sainsburys\HttpService\Components\ErrorHandling\ErrorController\DefaultErrorController;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -15,16 +16,28 @@ class DefaultErrorControllerSpec extends ObjectBehavior
         $this->shouldHaveType('Sainsburys\HttpService\Components\ErrorHandling\ErrorController\DefaultErrorController');
     }
 
-    function it_can_handle_errors()
+    function it_can_handle_errors(LoggerInterface $logger)
     {
         // ARRANGE
         $exception = new \Exception('message');
 
         // ACT
-        $result = $this->handleError($exception);
+        $result = $this->handleError($exception, $logger);
 
         // ASSERT
         $result->shouldHaveType('\Zend\Diactoros\Response\JsonResponse');
         $result->getStatusCode()->shouldBe(500);
+    }
+
+    function it_can_log_errors(LoggerInterface $logger)
+    {
+        // ARRANGE
+        $exception = new \Exception('message');
+
+        // ACT
+        $result = $this->handleError($exception, $logger);
+
+        // ASSERT
+        $logger->critical(Argument::any(), Argument::any())->shouldHaveBeenCalled();
     }
 }

--- a/tests/phpspec/SainsburysSpec/Sainsburys/HttpService/Components/Logging/LoggingManagerSpec.php
+++ b/tests/phpspec/SainsburysSpec/Sainsburys/HttpService/Components/Logging/LoggingManagerSpec.php
@@ -1,0 +1,30 @@
+<?php
+namespace SainsburysSpec\Sainsburys\HttpService\Components\Logging;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+use Sainsburys\HttpService\Components\Logging\LoggingManager;
+
+/**
+ * @mixin LoggingManager
+ */
+class LoggingManagerSpec extends ObjectBehavior
+{
+    function let(LoggerInterface $logger)
+    {
+        $this->beConstructedWith($logger);
+    }
+
+    function it_is_initialisable()
+    {
+        $this->shouldHaveType('Sainsburys\HttpService\Components\Logging\LoggingManager');
+    }
+
+    function it_can_accept_a_new_logger(LoggerInterface $logger, LoggerInterface $anotherLogger)
+    {
+        $this->logger()->shouldBe($logger);
+        $this->useThisLogger($anotherLogger);
+        $this->logger()->shouldBe($anotherLogger);
+    }
+}


### PR DESCRIPTION
Adds a null logger to the error controller.  Provides a way to replace the logger being used.  Provides documentation recommending the same logger be used in user code.