### PR TITLE
New middleware to handle unpack parameters feature

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -69,6 +69,7 @@ return [
             $middlewareManager = new \Sainsburys\HttpService\Components\Middlewares\MiddlewareManager();
             $middlewareManager->addToEndOfBeforeMiddlewareList($cleanRequestAttributesMiddleware);
             $middlewareManager->addToEndOfBeforeMiddlewareList($convertToJsonResponseObjectMiddleware);
+
             return $middlewareManager;
         },
 

--- a/src/Sainsburys/HttpService/Components/ErrorHandling/Exceptions/WithStatusCode/MalformedJsonRequest.php
+++ b/src/Sainsburys/HttpService/Components/ErrorHandling/Exceptions/WithStatusCode/MalformedJsonRequest.php
@@ -1,0 +1,14 @@
+<?php
+namespace Sainsburys\HttpService\Components\ErrorHandling\Exceptions\WithStatusCode;
+
+use Sainsburys\HttpService\Components\ErrorHandling\Exceptions\ExceptionWithHttpStatus;
+use Teapot\StatusCode\Http;
+
+class MalformedJsonRequest extends \RuntimeException implements ExceptionWithHttpStatus
+{
+
+    public function getHttpStatusCode(): int
+    {
+        return Http::BAD_REQUEST;
+    }
+}

--- a/src/Sainsburys/HttpService/Components/Middlewares/MiddlewareLibrary/BeforeMiddleware/UnpackJsonParametersToArray.php
+++ b/src/Sainsburys/HttpService/Components/Middlewares/MiddlewareLibrary/BeforeMiddleware/UnpackJsonParametersToArray.php
@@ -1,0 +1,59 @@
+<?php
+namespace Sainsburys\HttpService\Components\Middlewares\MiddlewareLibrary\BeforeMiddleware;
+
+use Sainsburys\HttpService\Components\Middlewares\Http\RequestAndResponse;
+use Sainsburys\HttpService\Components\Middlewares\MiddlewareInterfaces\BeforeMiddleware;
+use Sainsburys\HttpService\Components\ErrorHandling\Exceptions\WithStatusCode\MalformedJsonRequest;
+
+class UnpackJsonParametersToArray implements BeforeMiddleware
+{
+
+    private $originalParams;
+
+    private $proxyInjectedParams;
+
+    public function __construct(string $originalParams, string $proxyInjectedParams)
+    {
+        $this->originalParams      = $originalParams;
+        $this->proxyInjectedParams = $proxyInjectedParams;
+    }
+
+    public function apply(RequestAndResponse $originalRequestAndResponse): RequestAndResponse
+    {
+        $request = $originalRequestAndResponse->request();
+        $json    = $originalRequestAndResponse->request()->getBody()->getContents() ?? "{}";
+        $originalRequestAndResponse->request()->getBody()->rewind();
+
+        if ($request->getMethod() == 'GET') {
+            return $originalRequestAndResponse;
+        }
+
+        $proxyParams = json_decode($this->ifEmptyDefaultToEmptyJson($json), true);
+
+        if (json_last_error()) {
+            throw new MalformedJsonRequest(json_last_error_msg() ." " . $json);
+        }
+
+        $originalParams = $proxyParams[$this->originalParams] ?? [];
+
+        foreach ($proxyParams[$this->proxyInjectedParams] ?? [] as $key => $value) {
+            $k                  = preg_replace('/-/', '_', $key);
+            $originalParams[$k] = $value;
+        }
+
+        return new RequestAndResponse(
+            $newRequest = $request->withParsedBody($originalParams),
+            $originalRequestAndResponse->response()
+        );
+    }
+
+    public function getName(): string
+    {
+        return 'unpack-json-parameters-to-array';
+    }
+
+    public function ifEmptyDefaultToEmptyJson(string $json)
+    {
+        return empty($json) ? '{}' : $json;
+    }
+}


### PR DESCRIPTION
Hello, this PR should solve the unpacking of parameters once and for all. No need to duplicate the `unpackParameters` in every controller anymore.

To get parameters in the controller you can now do this:

`$params = $request->getParsedBody();`

I have tested this in FoodSafety service and applied it the two larger controllers : QA and FinalQuestions:  https://github.com/JSainsburyPLC/hara-foodsafetycriteria-service/pull/41

There is no conflict in using the old method in addition to this one, hopefully this one is a bit cleaner
